### PR TITLE
Use `crypto_bigint`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +40,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "itertools"
@@ -59,6 +75,8 @@ dependencies = [
 name = "mq-solver"
 version = "0.1.0"
 dependencies = [
+ "crypto-bigint",
+ "hex",
  "itertools",
  "mod_exp",
  "rand",
@@ -163,6 +181,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+crypto-bigint = "0.5.3"
+hex = "0.4.3"
 itertools = "0.11.0"
 mod_exp = "1.0.1"
 rand = "0.8.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod ntt;
+pub mod numbers;
 pub mod polynomial;
 pub mod prime;
-

--- a/src/ntt.rs
+++ b/src/ntt.rs
@@ -1,36 +1,34 @@
-use crate::prime::is_prime;
-use core::panic;
+use crate::{numbers::BigInt, prime::is_prime};
 use itertools::Itertools;
 use mod_exp::mod_exp;
-use std::mem::swap;
 
 #[derive(Debug, Clone)]
 pub struct Constants {
-    pub k: i64,
-    pub N: i64,
-    pub w: i64,
+    pub k: BigInt,
+    pub N: BigInt,
+    pub w: BigInt,
 }
 
-fn extended_gcd(a: i64, b: i64) -> i64 {
+fn extended_gcd(a: BigInt, b: BigInt) -> BigInt {
     let mut a = a;
     let mut b = b;
     let n = b;
-    let mut q = 0;
-    let mut r = 1;
-    let mut s1 = 1;
-    let mut s2 = 0;
-    let mut s3 = 1;
-    let mut t1 = 0;
-    let mut t2 = 1;
-    let mut t3 = 0;
+    let mut q = BigInt::from(0);
+    let mut r = BigInt::from(1);
+    let mut s1 = BigInt::from(1);
+    let mut s2 = BigInt::from(0);
+    let mut s3 = BigInt::from(1);
+    let mut t1 = BigInt::from(0);
+    let mut t2 = BigInt::from(1);
+    let mut t3 = BigInt::from(0);
 
-    while r > 0 {
+    while r > BigInt::from(0) {
         q = b / a;
         r = b - q * a;
         s3 = s1 - q * s2;
         t3 = t1 - q * t2;
 
-        if r > 0 {
+        if r > BigInt::from(0) {
             b = a;
             a = r;
             s1 = s2;
@@ -39,47 +37,51 @@ fn extended_gcd(a: i64, b: i64) -> i64 {
             t2 = t3;
         }
     }
-    (t2 + n) % n
+    (t2 + n).rem(n)
 }
 
-fn prime_factors(a: i64) -> Vec<i64> {
-    let mut ans: Vec<i64> = Vec::new();
-    (2..(((a as f64).sqrt() + 1.) as i64)).for_each(|x| {
-        if a % x == 0 {
+fn prime_factors(a: BigInt) -> Vec<BigInt> {
+    let mut ans: Vec<BigInt> = Vec::new();
+    let mut x = BigInt::from(2);
+    while x <= a.sqrt() {
+        if a.rem(x) == 0 {
             ans.push(x);
         }
-    });
+        x += 1;
+    }
     ans
 }
 
-fn is_primitive_root(a: i64, deg: i64, N: i64) -> bool {
-    mod_exp(a, deg, N) == 1
-        && prime_factors(deg)
-            .iter()
-            .map(|&x| mod_exp(a, deg / x, N) != 1)
-            .all(|x| x)
+fn is_primitive_root(a: BigInt, deg: BigInt, N: BigInt) -> bool {
+    let lhs = a.mod_exp(deg, N) == 1;
+    let pf = prime_factors(deg);
+    let rhs: Vec<bool> = pf.iter().map(|&x| a.mod_exp(deg / x, N) != 1).collect();
+    // .all(|x| x);
+    lhs && rhs.iter().all(|&x| x)
 }
 
-pub fn working_modulus(n: i64, M: i64) -> Constants {
+pub fn working_modulus(n: BigInt, M: BigInt) -> Constants {
     let mut N = n + 1;
-    let mut k = 1;
+    let mut k = BigInt::from(1);
     while (!is_prime(N)) || N < M {
         k += 1;
         N = k * n + 1;
     }
-    let mut gen = 0;
-    for g in 2..N {
+    let mut gen = BigInt::from(0);
+    let mut g = BigInt::from(2);
+    while g < N {
         if is_primitive_root(g, N - 1, N) {
             gen = g;
             break;
         }
+        g += BigInt::from(1);
     }
     assert!(gen > 0);
-    let w = mod_exp(gen, k, N);
+    let w = gen.mod_exp(k, N);
     Constants { k, N, w }
 }
 
-fn order_reverse(inp: &mut Vec<i64>) {
+fn order_reverse(inp: &mut Vec<BigInt>) {
     let mut j = 0;
     let n = inp.len();
     (1..n).for_each(|i| {
@@ -96,12 +98,12 @@ fn order_reverse(inp: &mut Vec<i64>) {
     });
 }
 
-fn fft(inp: Vec<i64>, c: &Constants, w: i64) -> Vec<i64> {
+fn fft(inp: Vec<BigInt>, c: &Constants, w: BigInt) -> Vec<BigInt> {
     let mut inp = inp.clone();
     let N = inp.len();
-    let mut pre = vec![1; N / 2];
+    let mut pre: Vec<BigInt> = vec![BigInt::from(1); N / 2];
 
-    (1..N / 2).for_each(|i| pre[i] = (pre[i - 1] * w).rem_euclid(c.N));
+    (1..N / 2).for_each(|i| pre[i] = (pre[i - 1] * w).rem(BigInt::from(c.N)));
     order_reverse(&mut inp);
 
     let mut len = 2;
@@ -115,8 +117,8 @@ fn fft(inp: Vec<i64>, c: &Constants, w: i64) -> Vec<i64> {
                 let l = j + half;
                 let left = inp[j];
                 let right = inp[l] * pre[k];
-                inp[j] = (left + right).rem_euclid(c.N);
-                inp[l] = (left - right).rem_euclid(c.N);
+                inp[j] = (left + right).rem(BigInt::from(c.N));
+                inp[l] = (left - right).rem(BigInt::from(c.N));
                 k += pre_step;
             })
         });
@@ -125,17 +127,17 @@ fn fft(inp: Vec<i64>, c: &Constants, w: i64) -> Vec<i64> {
     inp
 }
 
-pub fn forward(inp: Vec<i64>, c: &Constants) -> Vec<i64> {
+pub fn forward(inp: Vec<BigInt>, c: &Constants) -> Vec<BigInt> {
     fft(inp, c, c.w)
 }
 
-pub fn inverse(inp: Vec<i64>, c: &Constants) -> Vec<i64> {
-    let inv = extended_gcd(inp.len() as i64, c.N);
+pub fn inverse(inp: Vec<BigInt>, c: &Constants) -> Vec<BigInt> {
+    let inv = extended_gcd(BigInt::from(inp.len()), BigInt::from(c.N));
     let w = extended_gcd(c.w, c.N);
 
     fft(inp, c, w)
         .iter()
-        .map(|&x| (inv * x).rem_euclid(c.N))
+        .map(|&x| (inv * x).rem(c.N))
         .collect_vec()
 }
 
@@ -143,25 +145,31 @@ pub fn inverse(inp: Vec<i64>, c: &Constants) -> Vec<i64> {
 mod tests {
     use rand::Rng;
 
-    use crate::ntt::{extended_gcd, forward, inverse, working_modulus, Constants};
+    use crate::{
+        ntt::{extended_gcd, forward, inverse, working_modulus, Constants},
+        numbers::BigInt,
+    };
 
     #[test]
     fn test_forward() {
-        let n = rand::thread_rng().gen::<i64>().abs() % 10;
-        let v: Vec<i64> = (0..n)
-            .map(|_| rand::thread_rng().gen::<i64>().abs() % (1 << 6))
+        let n = rand::thread_rng().gen::<i32>().abs() % 10;
+        let v: Vec<BigInt> = (0..n)
+            .map(|_| BigInt::from(rand::thread_rng().gen::<i32>().abs() % (1 << 6)))
             .collect();
-        let M = v.iter().max().unwrap().pow(2) as i64 * n + 1;
-        let c = working_modulus(n, M);
+        let M = (*v.iter().max().unwrap() << 1) * BigInt::from(n) + 1;
+        let c = working_modulus(BigInt::from(n), BigInt::from(M));
         let forward = forward(v.clone(), &c);
         let inverse = inverse(forward, &c);
         v.iter().zip(inverse).for_each(|(&a, b)| assert_eq!(a, b));
     }
     #[test]
     fn test_extended_gcd() {
-        (2..11).for_each(|x| {
-            let inv = extended_gcd(x, 11);
-            assert_eq!((x * inv) % 11, 1);
+        (2..11).for_each(|x: u64| {
+            let inv = extended_gcd(BigInt::from(x), BigInt::from(11));
+            assert_eq!(
+                (BigInt::from(x) * inv).rem(BigInt::from(11)),
+                BigInt::from(1)
+            );
         });
     }
 }

--- a/src/numbers.rs
+++ b/src/numbers.rs
@@ -1,0 +1,562 @@
+use std::{
+    fmt::Display,
+    num::NonZeroU128,
+    ops::{
+        Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Neg, Shl, ShlAssign, Shr,
+        ShrAssign, Sub, SubAssign,
+    },
+};
+
+use crypto_bigint::{Invert, NonZero, Wrapping, U128, U256};
+use itertools::Itertools;
+
+pub enum BigIntType {
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BigInt {
+    v: U256,
+}
+
+impl BigInt {
+    pub fn new(_v: BigIntType) -> Self {
+        Self {
+            v: match _v {
+                BigIntType::U16(x) => U256::from(x),
+                BigIntType::U32(x) => U256::from(x),
+                BigIntType::U64(x) => U256::from(x),
+                BigIntType::U128(x) => U256::from(x),
+                _ => panic!("received invalid `BigIntType`"),
+            },
+        }
+    }
+
+    pub fn rem(&self, num: BigInt) -> Self {
+        BigInt {
+            v: self.v.const_rem(&num.v).0,
+        }
+    }
+
+    pub fn mod_exp(&self, exp: BigInt, M: BigInt) -> BigInt {
+        let mut res: BigInt = if exp & 1 > 0 {
+            self.clone()
+        } else {
+            BigInt::from(1)
+        };
+        let mut b = self.clone();
+        let mut e = exp.clone();
+        while e > 0 {
+            e >>= 1;
+            b = (b * b).rem(M);
+            if e & 1 > 0 {
+                res = (res * b).rem(M);
+            }
+        }
+        res
+    }
+
+    pub fn sqrt(&self) -> BigInt {
+        BigInt {
+            v: self.v.sqrt_vartime(),
+        }
+    }
+}
+
+impl From<u16> for BigInt {
+    fn from(value: u16) -> Self {
+        BigInt::new(BigIntType::U16(value))
+    }
+}
+
+impl From<i32> for BigInt {
+    fn from(value: i32) -> Self {
+        BigInt::new(BigIntType::U32(value as u32))
+    }
+}
+
+impl From<usize> for BigInt {
+    fn from(value: usize) -> Self {
+        BigInt::new(BigIntType::U64(value as u64))
+    }
+}
+
+impl From<u32> for BigInt {
+    fn from(value: u32) -> Self {
+        BigInt::new(BigIntType::U32(value))
+    }
+}
+
+impl From<u64> for BigInt {
+    fn from(value: u64) -> Self {
+        BigInt::new(BigIntType::U64(value))
+    }
+}
+
+impl From<u128> for BigInt {
+    fn from(value: u128) -> Self {
+        BigInt::new(BigIntType::U128(value))
+    }
+}
+
+impl Add for BigInt {
+    type Output = BigInt;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            v: (Wrapping(self.v) + Wrapping(rhs.v)).0,
+        }
+    }
+}
+
+impl Add<u16> for BigInt {
+    type Output = BigInt;
+
+    fn add(self, rhs: u16) -> Self::Output {
+        Self {
+            v: (Wrapping(self.v) + Wrapping(BigInt::from(rhs).v)).0,
+        }
+    }
+}
+
+impl Add<i32> for BigInt {
+    type Output = BigInt;
+
+    fn add(self, rhs: i32) -> Self::Output {
+        Self {
+            v: (Wrapping(self.v) + Wrapping(BigInt::from(rhs).v)).0,
+        }
+    }
+}
+
+impl Add<u32> for BigInt {
+    type Output = BigInt;
+
+    fn add(self, rhs: u32) -> Self::Output {
+        Self {
+            v: (-Wrapping(BigInt::from(rhs).v)).0,
+        }
+    }
+}
+
+impl Add<u64> for BigInt {
+    type Output = BigInt;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Self {
+            v: (Wrapping(self.v) + Wrapping(BigInt::from(rhs).v)).0,
+        }
+    }
+}
+
+impl Add<u128> for BigInt {
+    type Output = BigInt;
+
+    fn add(self, rhs: u128) -> Self::Output {
+        Self {
+            v: (Wrapping(self.v) + Wrapping(BigInt::from(rhs).v)).0,
+        }
+    }
+}
+
+impl AddAssign for BigInt {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs
+    }
+}
+
+impl AddAssign<u16> for BigInt {
+    fn add_assign(&mut self, rhs: u16) {
+        *self = *self + BigInt::from(rhs);
+    }
+}
+
+impl AddAssign<u32> for BigInt {
+    fn add_assign(&mut self, rhs: u32) {
+        *self = *self + BigInt::from(rhs);
+    }
+}
+
+impl AddAssign<i32> for BigInt {
+    fn add_assign(&mut self, rhs: i32) {
+        *self = *self + BigInt::from(rhs);
+    }
+}
+
+impl AddAssign<u64> for BigInt {
+    fn add_assign(&mut self, rhs: u64) {
+        *self = *self + BigInt::from(rhs);
+    }
+}
+
+impl AddAssign<u128> for BigInt {
+    fn add_assign(&mut self, rhs: u128) {
+        *self = *self + BigInt::from(rhs);
+    }
+}
+
+impl Sub for BigInt {
+    type Output = BigInt;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        BigInt {
+            v: (Wrapping(self.v) - Wrapping(rhs.v)).0,
+        }
+    }
+}
+
+impl Sub<usize> for BigInt {
+    type Output = BigInt;
+
+    fn sub(self, rhs: usize) -> Self::Output {
+        self - BigInt::from(rhs)
+    }
+}
+
+impl Sub<u16> for BigInt {
+    type Output = BigInt;
+
+    fn sub(self, rhs: u16) -> Self::Output {
+        self - BigInt::from(rhs)
+    }
+}
+
+impl Sub<u32> for BigInt {
+    type Output = BigInt;
+
+    fn sub(self, rhs: u32) -> Self::Output {
+        self - BigInt::from(rhs)
+    }
+}
+
+impl Sub<i32> for BigInt {
+    type Output = BigInt;
+
+    fn sub(self, rhs: i32) -> Self::Output {
+        self - BigInt::from(rhs)
+    }
+}
+
+impl Sub<u64> for BigInt {
+    type Output = BigInt;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        self - BigInt::from(rhs)
+    }
+}
+
+impl Sub<u128> for BigInt {
+    type Output = BigInt;
+
+    fn sub(self, rhs: u128) -> Self::Output {
+        self - BigInt::from(rhs)
+    }
+}
+
+impl SubAssign for BigInt {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs
+    }
+}
+
+impl SubAssign<u16> for BigInt {
+    fn sub_assign(&mut self, rhs: u16) {
+        *self = *self - BigInt::from(rhs);
+    }
+}
+
+impl SubAssign<u32> for BigInt {
+    fn sub_assign(&mut self, rhs: u32) {
+        *self = *self - BigInt::from(rhs);
+    }
+}
+
+impl SubAssign<i32> for BigInt {
+    fn sub_assign(&mut self, rhs: i32) {
+        *self = *self - BigInt::from(rhs);
+    }
+}
+
+impl SubAssign<u64> for BigInt {
+    fn sub_assign(&mut self, rhs: u64) {
+        *self = *self - BigInt::from(rhs);
+    }
+}
+
+impl SubAssign<u128> for BigInt {
+    fn sub_assign(&mut self, rhs: u128) {
+        *self = *self - BigInt::from(rhs);
+    }
+}
+
+impl Neg for BigInt {
+    type Output = BigInt;
+
+    fn neg(self) -> Self::Output {
+        Self {
+            v: (Wrapping(U256::MAX) - Wrapping(self.v)).0,
+        }
+    }
+}
+
+impl Mul for BigInt {
+    type Output = BigInt;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self {
+            v: (Wrapping(self.v) * Wrapping(rhs.v)).0,
+        }
+    }
+}
+
+impl MulAssign for BigInt {
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs
+    }
+}
+
+impl Div for BigInt {
+    type Output = BigInt;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        let [lower, upper, _, _] = rhs.v.to_words();
+        let half = (upper as u128) << 64;
+        let half = half + (lower as u128);
+        BigInt {
+            v: (Wrapping(self.v) / NonZero::from(NonZeroU128::new(half).unwrap())).0,
+        }
+    }
+}
+
+impl Invert for BigInt {
+    type Output = BigInt;
+
+    fn invert(&self) -> Self::Output {
+        BigInt {
+            v: self.v.inv_mod(&U256::MAX).0,
+        }
+    }
+}
+
+impl DivAssign for BigInt {
+    fn div_assign(&mut self, rhs: Self) {
+        *self = *self / rhs;
+    }
+}
+
+impl Eq for BigInt {}
+
+impl Ord for BigInt {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.v.cmp(&other.v)
+    }
+}
+
+impl PartialEq for BigInt {
+    fn eq(&self, other: &Self) -> bool {
+        self.v == other.v
+    }
+}
+
+impl PartialEq<u16> for BigInt {
+    fn eq(&self, other: &u16) -> bool {
+        self.v == BigInt::from(*other).v
+    }
+}
+
+impl PartialEq<i32> for BigInt {
+    fn eq(&self, other: &i32) -> bool {
+        self.v == BigInt::from(*other).v
+    }
+}
+
+impl PartialEq<u32> for BigInt {
+    fn eq(&self, other: &u32) -> bool {
+        self.v == BigInt::from(*other).v
+    }
+}
+
+impl PartialEq<u64> for BigInt {
+    fn eq(&self, other: &u64) -> bool {
+        self.v == BigInt::from(*other).v
+    }
+}
+
+impl PartialEq<u128> for BigInt {
+    fn eq(&self, other: &u128) -> bool {
+        self.v == BigInt::from(*other).v
+    }
+}
+
+impl PartialOrd for BigInt {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.v.partial_cmp(&other.v)
+    }
+}
+
+impl PartialOrd<u16> for BigInt {
+    fn partial_cmp(&self, other: &u16) -> Option<std::cmp::Ordering> {
+        self.v.partial_cmp(&BigInt::from(*other).v)
+    }
+}
+
+impl PartialOrd<i32> for BigInt {
+    fn partial_cmp(&self, other: &i32) -> Option<std::cmp::Ordering> {
+        self.v.partial_cmp(&BigInt::from(*other).v)
+    }
+}
+
+impl PartialOrd<u32> for BigInt {
+    fn partial_cmp(&self, other: &u32) -> Option<std::cmp::Ordering> {
+        self.v.partial_cmp(&BigInt::from(*other).v)
+    }
+}
+
+impl PartialOrd<u64> for BigInt {
+    fn partial_cmp(&self, other: &u64) -> Option<std::cmp::Ordering> {
+        self.v.partial_cmp(&BigInt::from(*other).v)
+    }
+}
+
+impl PartialOrd<u128> for BigInt {
+    fn partial_cmp(&self, other: &u128) -> Option<std::cmp::Ordering> {
+        self.v.partial_cmp(&BigInt::from(*other).v)
+    }
+}
+
+impl BitAnd for BigInt {
+    type Output = BigInt;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        BigInt { v: self.v & rhs.v }
+    }
+}
+
+impl BitAnd<u16> for BigInt {
+    type Output = BigInt;
+
+    fn bitand(self, rhs: u16) -> Self::Output {
+        BigInt {
+            v: self.v & BigInt::from(rhs).v,
+        }
+    }
+}
+
+impl BitAnd<i32> for BigInt {
+    type Output = BigInt;
+
+    fn bitand(self, rhs: i32) -> Self::Output {
+        BigInt {
+            v: self.v & BigInt::from(rhs).v,
+        }
+    }
+}
+
+impl BitAnd<u32> for BigInt {
+    type Output = BigInt;
+
+    fn bitand(self, rhs: u32) -> Self::Output {
+        BigInt {
+            v: self.v & BigInt::from(rhs).v,
+        }
+    }
+}
+
+impl BitAnd<u64> for BigInt {
+    type Output = BigInt;
+
+    fn bitand(self, rhs: u64) -> Self::Output {
+        BigInt {
+            v: self.v & BigInt::from(rhs).v,
+        }
+    }
+}
+
+impl BitAnd<u128> for BigInt {
+    type Output = BigInt;
+
+    fn bitand(self, rhs: u128) -> Self::Output {
+        BigInt {
+            v: self.v & BigInt::from(rhs).v,
+        }
+    }
+}
+
+impl Shl<usize> for BigInt {
+    type Output = BigInt;
+
+    fn shl(self, rhs: usize) -> Self::Output {
+        BigInt { v: self.v << rhs }
+    }
+}
+
+impl Shr<usize> for BigInt {
+    type Output = BigInt;
+
+    fn shr(self, rhs: usize) -> Self::Output {
+        BigInt { v: self.v >> rhs }
+    }
+}
+
+impl ShrAssign<usize> for BigInt {
+    fn shr_assign(&mut self, rhs: usize) {
+        *self = *self >> rhs;
+    }
+}
+
+impl ShlAssign<usize> for BigInt {
+    fn shl_assign(&mut self, rhs: usize) {
+        *self = *self << rhs;
+    }
+}
+
+impl Display for BigInt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // concatenate bytes to string representation
+        let str: String = self
+            .v
+            .to_words()
+            .iter()
+            .rev()
+            .map(|&x| x.to_string())
+            .join("");
+
+        let mut trimmed = str.trim_start_matches('0').to_string();
+
+        // in case the string is "0000"
+        if str.ends_with('0') {
+            trimmed = "0".to_string();
+        }
+
+        write!(f, "{}", trimmed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::numbers::BigInt;
+    use mod_exp::mod_exp;
+
+    #[test]
+    fn test_mod_exp() {
+        let N = 73;
+        (2..10).for_each(|x| {
+            (2..10).for_each(|y| {
+                assert_eq!(
+                    BigInt::from(mod_exp(x, y, N)),
+                    BigInt::from(x).mod_exp(BigInt::from(y), BigInt::from(N))
+                );
+            })
+        })
+    }
+
+    #[test]
+    fn test_division() {
+        let a = BigInt::from(8);
+        let b = BigInt::from(10);
+        println!("{}", a / b);
+    }
+}

--- a/src/numbers.rs
+++ b/src/numbers.rs
@@ -7,7 +7,7 @@ use std::{
     },
 };
 
-use crypto_bigint::{Invert, NonZero, Wrapping, U128, U256};
+use crypto_bigint::{Invert, NonZero, Wrapping, U256};
 use itertools::Itertools;
 
 pub enum BigIntType {
@@ -62,6 +62,18 @@ impl BigInt {
     pub fn sqrt(&self) -> BigInt {
         BigInt {
             v: self.v.sqrt_vartime(),
+        }
+    }
+
+    pub fn add_mod(&self, rhs: BigInt, M: BigInt) -> BigInt {
+        (*self + rhs).rem(M)
+    }
+
+    pub fn sub_mod(&self, rhs: BigInt, M: BigInt) -> BigInt {
+        if rhs > *self {
+            M - (rhs - *self).rem(M)
+        } else {
+            (*self - rhs).rem(M)
         }
     }
 }
@@ -527,7 +539,7 @@ impl Display for BigInt {
         let mut trimmed = str.trim_start_matches('0').to_string();
 
         // in case the string is "0000"
-        if str.ends_with('0') {
+        if str.chars().all(|x| x == '0') {
             trimmed = "0".to_string();
         }
 
@@ -558,5 +570,26 @@ mod tests {
         let a = BigInt::from(8);
         let b = BigInt::from(10);
         println!("{}", a / b);
+    }
+
+    #[test]
+    fn test_rem() {
+        let a = BigInt::from(10);
+        println!("{}", a.rem(BigInt::from(4)));
+    }
+
+    #[test]
+    fn test_display() {
+        let a = BigInt::from(111);
+        println!("{}", a);
+    }
+
+    #[test]
+    fn test_add_mod() {
+        let a = BigInt::from(72);
+        let b = BigInt::from(1890);
+        let N = BigInt::from(73);
+
+        println!("{}", a.sub_mod(b, N));
     }
 }

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -1,6 +1,5 @@
 use std::{
     fmt::Display,
-    mem::swap,
     ops::{Add, Mul, Neg, Sub},
 };
 
@@ -30,7 +29,7 @@ impl Polynomial {
         Self { coef }
     }
     pub fn diff(mut self) -> Self {
-        let N = self.coef.len();
+        let N = self.len();
         for n in (1..N).rev() {
             self.coef[n] = self.coef[n - 1] * BigInt::from(N - n);
         }
@@ -39,6 +38,15 @@ impl Polynomial {
         self.coef = self.coef[start..].to_vec();
 
         self
+    }
+
+    pub fn len(&self) -> usize {
+        self.coef.len()
+    }
+
+    pub fn degree(&self) -> usize {
+        let start = self.coef.iter().position(|&x| x != 0).unwrap();
+        self.len() - start - 1
     }
 }
 
@@ -85,11 +93,11 @@ impl Mul<Polynomial> for Polynomial {
     type Output = Polynomial;
 
     fn mul(self, rhs: Polynomial) -> Self::Output {
+        let v1_deg = self.degree();
+        let v2_deg = rhs.degree();
         let mut v1 = self.coef;
         let mut v2 = rhs.coef;
         let n = (v1.len() + v2.len()).next_power_of_two();
-        let v1_deg = v1.len() - 1;
-        let v2_deg = v2.len() - 1;
 
         v1 = vec![BigInt::from(0); n - v1.len()]
             .into_iter()
@@ -123,7 +131,7 @@ impl Mul<Polynomial> for Polynomial {
         let start = coef.iter().position(|&x| x != 0).unwrap();
 
         Polynomial {
-            coef: coef[start..(start + v1_deg + v2_deg)].to_vec(),
+            coef: coef[start..=(start + v1_deg + v2_deg)].to_vec(),
         }
     }
 }
@@ -148,8 +156,13 @@ mod tests {
 
     #[test]
     fn mul() {
-        let a = Polynomial::new(vec![1, 2].iter().map(|&x| BigInt::from(x)).collect());
-        let b = Polynomial::new(vec![1, 2].iter().map(|&x| BigInt::from(x)).collect());
+        let a = Polynomial::new(vec![1, 2, 3].iter().map(|&x| BigInt::from(x)).collect());
+        let b = Polynomial::new(
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9]
+                .iter()
+                .map(|&x| BigInt::from(x))
+                .collect(),
+        );
         println!("{}", a * b);
     }
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -1,26 +1,27 @@
 use std::{
+    fmt::Display,
     mem::swap,
     ops::{Add, Mul, Neg, Sub},
 };
 
 use itertools::{EitherOrBoth::*, Itertools};
 
-use crate::ntt::*;
+use crate::{ntt::*, numbers::BigInt};
 
 #[derive(Debug, Clone)]
 pub struct Polynomial {
-    pub coef: Vec<i64>,
+    pub coef: Vec<BigInt>,
 }
 
 impl Polynomial {
-    pub fn new(coef: Vec<i64>) -> Self {
+    pub fn new(coef: Vec<BigInt>) -> Self {
         let n = coef.len();
 
         // if is not power of 2
         if !(n & (n - 1) == 0) {
             let pad = n.next_power_of_two() - n;
             return Self {
-                coef: vec![0; pad]
+                coef: vec![BigInt::from(0); pad]
                     .into_iter()
                     .chain(coef.into_iter())
                     .collect_vec(),
@@ -31,10 +32,11 @@ impl Polynomial {
     pub fn diff(mut self) -> Self {
         let N = self.coef.len();
         for n in (1..N).rev() {
-            self.coef[n] = self.coef[n - 1] * ((N - n) as i64);
+            self.coef[n] = self.coef[n - 1] * BigInt::from(N - n);
         }
-        self.coef[0] = 0;
-        self.coef = self.coef[1..].to_vec();
+        self.coef[0] = BigInt::from(0);
+        let start = self.coef.iter().position(|&x| x != 0).unwrap();
+        self.coef = self.coef[start..].to_vec();
 
         self
     }
@@ -74,7 +76,7 @@ impl Neg for Polynomial {
 
     fn neg(self) -> Self::Output {
         Polynomial {
-            coef: self.coef.iter().map(|a| -a).collect(),
+            coef: self.coef.iter().map(|a| -(*a)).collect(),
         }
     }
 }
@@ -85,61 +87,39 @@ impl Mul<Polynomial> for Polynomial {
     fn mul(self, rhs: Polynomial) -> Self::Output {
         let mut v1 = self.coef;
         let mut v2 = rhs.coef;
-        let n = (v1.len() + v2.len()).next_power_of_two() as i64;
+        let n = (v1.len() + v2.len()).next_power_of_two();
         let v1_deg = v1.len() - 1;
         let v2_deg = v2.len() - 1;
 
-        v1 = vec![0; (n - v1.len() as i64) as usize]
+        v1 = vec![BigInt::from(0); n - v1.len()]
             .into_iter()
             .chain(v1.into_iter())
             .collect();
-        v2 = vec![0; (n - v2.len() as i64) as usize]
+        v2 = vec![BigInt::from(0); n - v2.len()]
             .into_iter()
             .chain(v2.into_iter())
             .collect();
 
-        let M = v1
-            .iter()
-            .map(|x| x.abs())
-            .max()
-            .unwrap()
-            .max(v2.iter().map(|x| x.abs()).max().unwrap())
-            .pow(2) as i64
-            * n
-            + 1;
-        let c = working_modulus(n, M);
-
-        v1.iter_mut().for_each(|x| {
-            if *x < 0 {
-                *x = (*x).rem_euclid(M)
-            }
-        });
-        v2.iter_mut().for_each(|x| {
-            if *x < 0 {
-                *x = (*x).rem_euclid(M)
-            }
-        });
+        let N = BigInt::from(n);
+        let M = (*v1.iter().max().unwrap().max(v2.iter().max().unwrap()) << 1) * N + 1;
+        let c = working_modulus(N, M);
 
         let a_forward = forward(v1, &c);
         let b_forward = forward(v2, &c);
 
-        let mut mul: Vec<i64> = vec![0; n as usize];
+        let mut mul = vec![BigInt::from(0); n as usize];
         a_forward
             .iter()
             .rev()
             .zip_longest(b_forward.iter().rev())
             .enumerate()
             .for_each(|(i, p)| match p {
-                Both(&a, &b) => mul[i] = (a * b) % c.N,
+                Both(&a, &b) => mul[i] = (a * b).rem(c.N),
                 Left(_) => {}
                 Right(_) => {}
             });
         mul.reverse();
-        let coef = inverse(mul, &c)
-            .iter()
-            .map(|&x| if x > M / 2 { -(M - x.rem_euclid(M)) } else { x })
-            .collect::<Vec<i64>>()
-            .to_vec();
+        let coef = inverse(mul, &c);
         let start = coef.iter().position(|&x| x != 0).unwrap();
 
         Polynomial {
@@ -148,28 +128,35 @@ impl Mul<Polynomial> for Polynomial {
     }
 }
 
+impl Display for Polynomial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.coef.iter().map(|&x| write!(f, "{} ", x)).collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Polynomial;
+    use crate::numbers::BigInt;
 
     #[test]
     fn add() {
-        let a = Polynomial::new(vec![1, 2, 3, 4]);
-        let b = Polynomial::new(vec![1, 2]);
-        println!("{:?}", a + b);
+        let a = Polynomial::new(vec![1, 2, 3, 4].iter().map(|&x| BigInt::from(x)).collect());
+        let b = Polynomial::new(vec![1, 2].iter().map(|&x| BigInt::from(x)).collect());
+        println!("{}", a + b);
     }
 
     #[test]
     fn mul() {
-        let a = Polynomial::new(vec![1, -2, 3]);
-        let b = Polynomial::new(vec![1, -3]);
-        println!("{:?}", a * b);
+        let a = Polynomial::new(vec![1, 2].iter().map(|&x| BigInt::from(x)).collect());
+        let b = Polynomial::new(vec![1, 2].iter().map(|&x| BigInt::from(x)).collect());
+        println!("{}", a * b);
     }
 
     #[test]
     fn diff() {
-        let a = Polynomial::new(vec![3, 2, 1]);
+        let a = Polynomial::new(vec![3, 2, 1].iter().map(|&x| BigInt::from(x)).collect());
         let da = a.diff();
-        println!("{:?}", da);
+        println!("{}", da);
     }
 }

--- a/src/prime.rs
+++ b/src/prime.rs
@@ -1,5 +1,3 @@
-use mod_exp::mod_exp;
-
 use crate::numbers::BigInt;
 
 fn check_composite(n: BigInt, a: BigInt, d: BigInt, s: BigInt) -> bool {

--- a/src/prime.rs
+++ b/src/prime.rs
@@ -1,32 +1,36 @@
 use mod_exp::mod_exp;
 
-fn check_composite(n: i64, a: i64, d: i64, s: i64) -> bool {
-    let mut x = mod_exp(a, d, n);
+use crate::numbers::BigInt;
+
+fn check_composite(n: BigInt, a: BigInt, d: BigInt, s: BigInt) -> bool {
+    let mut x = a.mod_exp(d, n);
     if x == 1 || x == n - 1 {
         return false;
     }
-    for _ in 1..s {
-        x = x * x % n;
+    let mut i = BigInt::from(1);
+    while i < s {
+        x = (x * x).rem(n);
         if x == n - 1 {
             return false;
         }
+        i += 1;
     }
     return true;
 }
 
-pub fn is_prime(n: i64) -> bool {
+pub fn is_prime(n: BigInt) -> bool {
     if n < 4 {
         return n == 2 || n == 3;
     }
-    let mut s = 0;
-    let mut d = n - 1;
-    while (d & 1) == 0 {
+    let mut s = BigInt::from(0);
+    let mut d: BigInt = n - 1;
+    while d.rem(BigInt::from(2)) == 0 {
         d >>= 1;
         s += 1;
     }
 
     for _ in 0..5 {
-        if check_composite(n, 2, d, s) {
+        if check_composite(n, BigInt::from(2), d, s) {
             return false;
         }
     }
@@ -35,11 +39,11 @@ pub fn is_prime(n: i64) -> bool {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::prime::is_prime;
+    use crate::{numbers::BigInt, prime::is_prime};
 
     #[test]
     pub fn test_is_prime() {
-        assert!(is_prime(11));
-        assert!(!is_prime(10));
+        assert!(is_prime(BigInt::from(11)));
+        assert!(!is_prime(BigInt::from(10)));
     }
 }


### PR DESCRIPTION
Currently, we are using integer primitives, which don't allow for large integer types (i.e. U256, etc.). Instead, we should use `crypto_bigint`, which is a faster integer library